### PR TITLE
Cap event capture requests at 100 events

### DIFF
--- a/src/schematic/event_buffer.py
+++ b/src/schematic/event_buffer.py
@@ -9,6 +9,10 @@ from .event_capture import AsyncEventCaptureClient, EventCaptureClient
 from .types import CreateEventRequestBody
 
 DEFAULT_MAX_EVENTS = 100  # Default maximum number of events
+# The capture service rejects any batch larger than this with
+# `400 {"error": "batch too large", "max_size": 100}`, so a flush is split into
+# chunks of at most this many events regardless of how many are buffered.
+MAX_EVENTS_PER_REQUEST = 100
 DEFAULT_EVENT_BUFFER_PERIOD = 5  # 5 seconds
 DEFAULT_MAX_RETRIES = 3  # Default maximum number of retry attempts
 DEFAULT_INITIAL_RETRY_DELAY = 1  # Initial retry delay in seconds
@@ -47,8 +51,14 @@ class EventBuffer:
             events_to_process = [event for event in self.events if event is not None]
             self.events.clear()
 
-        if events_to_process:
-            self._process_events(events_to_process)
+        # The buffer can hold more than one request's worth of events. push()
+        # appends unconditionally after its own flush, so concurrent producers
+        # can drive the backlog past max_events. Send in chunks so an oversized
+        # buffer is never turned into an oversized request. Each chunk retries
+        # on its own, since retrying the whole drained set would resend chunks
+        # that already succeeded.
+        for i in range(0, len(events_to_process), MAX_EVENTS_PER_REQUEST):
+            self._process_events(events_to_process[i:i + MAX_EVENTS_PER_REQUEST])
 
     def _process_events(self, events_to_process):
         """Process events with retry logic - called without holding lock"""
@@ -153,8 +163,10 @@ class AsyncEventBuffer:
             events_to_process = [event for event in self.events if event is not None]
             self.events.clear()
 
-        if events_to_process:
-            await self._process_events_async(events_to_process)
+        # See EventBuffer._flush: the buffer can exceed max_events, so cap the
+        # size of each request rather than sending the whole drained backlog.
+        for i in range(0, len(events_to_process), MAX_EVENTS_PER_REQUEST):
+            await self._process_events_async(events_to_process[i:i + MAX_EVENTS_PER_REQUEST])
 
     async def _process_events_async(self, events_to_process):
         """Process events with retry logic - called without holding lock"""

--- a/tests/custom/test_event_buffer.py
+++ b/tests/custom/test_event_buffer.py
@@ -321,3 +321,45 @@ class TestAsyncEventBuffer:
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestEventBufferBatchSizeCap(unittest.TestCase):
+    """The capture service rejects batches over 100 events, so no single
+    send_batch call may exceed that no matter how deep the backlog is."""
+
+    def setUp(self):
+        self.mock_sender = MagicMock()
+        self.mock_logger = MagicMock()
+
+    def _batch_sizes(self):
+        return [len(call.args[0]) for call in self.mock_sender.send_batch.call_args_list]
+
+    def test_flush_splits_backlog_into_capped_requests(self):
+        buffer = EventBuffer(
+            event_sender=self.mock_sender, logger=self.mock_logger, period=3600, max_events=1000
+        )
+        try:
+            buffer.events = [MagicMock(spec=CreateEventRequestBody) for _ in range(250)]
+            buffer._flush()
+        finally:
+            buffer.stop()
+
+        self.assertEqual(self._batch_sizes(), [100, 100, 50])
+
+
+class TestAsyncEventBufferBatchSizeCap(unittest.TestCase):
+
+    def test_flush_splits_backlog_into_capped_requests(self):
+        async def run():
+            mock_sender = AsyncMock()
+            buffer = AsyncEventBuffer(
+                event_sender=mock_sender, logger=MagicMock(), period=3600, max_events=1000
+            )
+            try:
+                buffer.events = [MagicMock(spec=CreateEventRequestBody) for _ in range(250)]
+                await buffer._flush()
+            finally:
+                await buffer.stop()
+            return [len(call.args[0]) for call in mock_sender.send_batch.call_args_list]
+
+        self.assertEqual(asyncio.run(run()), [100, 100, 50])


### PR DESCRIPTION
## Problem

The capture service rejects any batch over 100 events with `400 {"error": "batch too large", "max_size": 100}` ([`capture.go:73`](https://github.com/schematichq/schematic-api/blob/main/api/apps/events/web/capture.go)), but `_flush` drained the whole backlog into a single `send_batch` call.

## Severity, honestly

This is hardening rather than a live outage fix. Unlike `schematic-node` (where the default buffer size was 1000, see [schematic-node#162](https://github.com/SchematicHQ/schematic-node/pull/162)), `max_events` here already defaults to 100, so the ordinary single-producer path stays under the cap.

It is not a hard guarantee though. `push` appends unconditionally after its own flush:

```python
if should_flush:
    self._flush()
    with self.lock:
        self.events.append(event)
```

That tail has no length check, so producers piling up behind an in-flight send can drive the backlog past `max_events`. Exceeding 100 in a single request needs more than 100 concurrent pushers, which is narrow but reachable for a threaded web app. A caller who raises `max_events` themselves is exposed directly.

I tried to write a threaded regression test for the concurrent case and could not make it fail deterministically, so I did not ship a timing-dependent test that would flake in CI. The two tests here cover the deterministic property: a backlog larger than the cap must go out as multiple requests.

## Changes

Chunk each flush into requests of at most 100 events, in both `EventBuffer` and `AsyncEventBuffer`, so the cap holds regardless of `max_events` or producer concurrency. Each chunk retries on its own, since retrying the whole drained set would resend chunks that had already been delivered.

This matches `schematic-go`, `schematic-java`, and `schematic-csharp`, which all bound the drain rather than relying on the buffer size to stay small.

## Testing

Two new tests in `tests/custom/test_event_buffer.py`, both confirmed failing without the source change (a 250-event backlog goes out as one request instead of `[100, 100, 50]`):

- `TestEventBufferBatchSizeCap::test_flush_splits_backlog_into_capped_requests`
- `TestAsyncEventBufferBatchSizeCap::test_flush_splits_backlog_into_capped_requests`

Full `tests/custom/` suite passes: 161 passed.

## Context

Found while fixing a daily cron that tracked 113 companies through `schematic-node` and lost the whole batch to a 400. I checked every SDK with an event buffer: `schematic-go`, `schematic-java`, and `schematic-csharp` already hard-cap the drain and need no change; `schematic-node` and `schematic-ruby` have their own PRs; `schematic-js` sends events one at a time and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)